### PR TITLE
CU - Borrar puesto de trabajo

### DIFF
--- a/ParcialProgramacion4/src/Ejecutora.java
+++ b/ParcialProgramacion4/src/Ejecutora.java
@@ -101,7 +101,7 @@ public class Ejecutora {
 	            empresa.agregarPuesto();   
 	            break;
 	        case 4:
-	            	
+	            empresa.borrarPuesto();
 	            break;
 	        case 5:
 	            empresa.crearUnaHabilidad();

--- a/ParcialProgramacion4/src/Empresa.java
+++ b/ParcialProgramacion4/src/Empresa.java
@@ -109,4 +109,24 @@ public class Empresa {
         return null;
     }
     
+    //CASO DE USO BORRAR PUESTO DE TRABAJO
+    public void borrarPuesto() {
+        System.out.print("Nombre puesto de trabajo: ");
+        String nombrePuesto = scanner.nextLine();
+
+        Puesto puestoBorrar = this.buscarPuesto(nombrePuesto);
+
+        if (puestoBorrar != null) {
+            Logger.header("Informacion puesto a eliminar: ");
+            puestoBorrar.mostrar();
+
+            puestos.remove(puestoBorrar);
+
+            Logger.logSuccess("Puesto de trabajo ELIMINADO");
+
+        } else {
+            Logger.logError("NO existe puesto de trabajo con este nombre");
+        }
+    }
+
 }

--- a/ParcialProgramacion4/src/Empresa.java
+++ b/ParcialProgramacion4/src/Empresa.java
@@ -120,9 +120,16 @@ public class Empresa {
             Logger.header("Informacion puesto a eliminar: ");
             puestoBorrar.mostrar();
 
-            puestos.remove(puestoBorrar);
+            int cantEmpleados = puestoBorrar.cantEmpleados();
 
-            Logger.logSuccess("Puesto de trabajo ELIMINADO");
+            if (cantEmpleados == 0) {
+                puestos.remove(puestoBorrar);
+
+                Logger.logSuccess("Puesto de trabajo ELIMINADO");
+
+            } else {
+                Logger.logError("NO se puede eliminar, porque "+ cantEmpleados + " empleados tienen este puesto");
+            }
 
         } else {
             Logger.logError("NO existe puesto de trabajo con este nombre");

--- a/ParcialProgramacion4/src/Puesto.java
+++ b/ParcialProgramacion4/src/Puesto.java
@@ -20,4 +20,8 @@ public abstract class Puesto {
     public void mostrar() {
         System.out.println("Nombre: "+ nombre + " | sueldo: " + sueldo);
     }
+
+    public int cantEmpleados() {
+        return empleados.size();
+    }
 }

--- a/ParcialProgramacion4/src/Puesto.java
+++ b/ParcialProgramacion4/src/Puesto.java
@@ -16,4 +16,8 @@ public abstract class Puesto {
     public boolean hasNombre(String nombre) {
     	return this.nombre.equalsIgnoreCase(nombre);
     }
+
+    public void mostrar() {
+        System.out.println("Nombre: "+ nombre + " | sueldo: " + sueldo);
+    }
 }


### PR DESCRIPTION
Se borra solamente si ningún empleado tiene como cargo actual este puesto de trabajo. El puntero al puesto queda en el historial de cargos para puestos antiguos para poder ver los registros históricos, pero el usuario no puede registrar a un empleado en este puesto.