### PR TITLE
Correccion cu borrar puesto de trabajo

### DIFF
--- a/ParcialProgramacion4/src/Convocatoria.java
+++ b/ParcialProgramacion4/src/Convocatoria.java
@@ -100,4 +100,8 @@ public abstract class Convocatoria {
             System.out.println("años de experiencia: " + requisitos.get(habilidad));
         }
    }
+
+   public boolean hasPuesto(Puesto puesto) {
+        return this.puesto.equals(puesto);
+   }
 }

--- a/ParcialProgramacion4/src/Convocatoria.java
+++ b/ParcialProgramacion4/src/Convocatoria.java
@@ -117,7 +117,7 @@ public abstract class Convocatoria {
 
 
    public boolean hasPuesto(Puesto puesto) {
-        return this.puesto.equals(puesto);
+        return this.puesto == puesto;
    }
   
    public boolean tieneRequisito(Habilidad requisitoBuscado) {

--- a/ParcialProgramacion4/src/Empresa.java
+++ b/ParcialProgramacion4/src/Empresa.java
@@ -517,31 +517,28 @@ public class Empresa {
 
         Puesto puestoBorrar = this.buscarPuesto(nombrePuesto);
 
-        if (puestoBorrar != null) {
+        if (puestoBorrar == null) {
+            Logger.logError("NO existe puesto de trabajo con este nombre");
+        } else {
             Logger.header("Informacion puesto a eliminar: ");
             puestoBorrar.mostrar();
 
             int cantEmpleados = puestoBorrar.cantEmpleados();
 
-            if (cantEmpleados == 0) {
+            if (cantEmpleados != 0) {
+                Logger.logError("NO se puede eliminar, porque "+ cantEmpleados + " empleados tienen este puesto");
+            } else {
                 //buscar si esta en alguna convocatoria
                 boolean estaEnConvocatorias = puestoEstaEnConvocatorias(puestoBorrar);
 
-                if (!estaEnConvocatorias) {
+                if (estaEnConvocatorias) {
+                    Logger.logError("NO se puede eliminar, porque el puesto de " + nombrePuesto + " esta en convocatorias");
+                } else {
                     puestos.remove(puestoBorrar);
 
-                    Logger.logSuccess("Puesto de trabajo ELIMINADO");
-
-                } else {
-                    Logger.logError("NO se puede eliminar, porque el puesto de " + nombrePuesto + " esta en convocatorias");
+                    Logger.logSuccess("Puesto de trabajo " + nombrePuesto + " ha sido ELIMINADO");
                 }
-
-            } else {
-                Logger.logError("NO se puede eliminar, porque "+ cantEmpleados + " empleados tienen este puesto");
             }
-
-        } else {
-            Logger.logError("NO existe puesto de trabajo con este nombre");
         }
     }
 

--- a/ParcialProgramacion4/src/Empresa.java
+++ b/ParcialProgramacion4/src/Empresa.java
@@ -524,9 +524,17 @@ public class Empresa {
             int cantEmpleados = puestoBorrar.cantEmpleados();
 
             if (cantEmpleados == 0) {
-                puestos.remove(puestoBorrar);
+                //buscar si esta en alguna convocatoria
+                boolean estaEnConvocatorias = puestoEstaEnConvocatorias(puestoBorrar);
 
-                Logger.logSuccess("Puesto de trabajo ELIMINADO");
+                if (!estaEnConvocatorias) {
+                    puestos.remove(puestoBorrar);
+
+                    Logger.logSuccess("Puesto de trabajo ELIMINADO");
+
+                } else {
+                    Logger.logError("NO se puede eliminar, porque el puesto de " + nombrePuesto + " esta en convocatorias");
+                }
 
             } else {
                 Logger.logError("NO se puede eliminar, porque "+ cantEmpleados + " empleados tienen este puesto");
@@ -535,6 +543,15 @@ public class Empresa {
         } else {
             Logger.logError("NO existe puesto de trabajo con este nombre");
         }
+    }
+
+    private boolean puestoEstaEnConvocatorias(Puesto puesto) {
+        int i = 0;
+        while (i<convocatorias.size() && !convocatorias.get(i).hasPuesto(puesto)) {
+            i++;
+        }
+
+        return i<convocatorias.size(); //si es menor, significa que salio del while porque estaba en una convocatoria 
     }
 
 

--- a/ParcialProgramacion4/src/Empresa.java
+++ b/ParcialProgramacion4/src/Empresa.java
@@ -518,7 +518,7 @@ public class Empresa {
         Puesto puestoBorrar = this.buscarPuesto(nombrePuesto);
 
         if (puestoBorrar == null) {
-            Logger.logError("NO existe puesto de trabajo con este nombre");
+            Logger.logError("NO existe  el puesto de trabajo " + nombrePuesto);
         } else {
             Logger.header("Informacion puesto a eliminar: ");
             puestoBorrar.mostrar();


### PR DESCRIPTION
Se verifica que el puesto de trabajo no este en ninguna convocatoria, ya sea abierta o historica. En caso de que este en una convocatoria o que un empleado tenga ese puesto actualmente, se informa y no se elimina.
Tambien se modifica la estructura if else, para que queden los errores primero y la ejecucion normal en el else.